### PR TITLE
Load ETW module from a specified path

### DIFF
--- a/src/compiler/perfLogger.ts
+++ b/src/compiler/perfLogger.ts
@@ -28,9 +28,11 @@ namespace ts {
     // See https://github.com/microsoft/typescript-etw for more information
     let etwModule;
     try {
-        // require() will throw an exception if the module is not installed
+        const etwModulePath = process.env.TS_ETW_MODULE_PATH ?? "./node_modules/@microsoft/typescript-etw";
+
+        // require() will throw an exception if the module is not found
         // It may also return undefined if not installed properly
-        etwModule = require("@microsoft/typescript-etw");
+        etwModule = require(etwModulePath);
     }
     catch (e) {
         etwModule = undefined;


### PR DESCRIPTION
Do not rely on the default module resolution algorithm to load the optional typescript-etw module. Load it from the node_modules path that is local to the running server. This is where it is shipped with the Windows TypeScript SDK.

Also allow the path to be specified with the TS_ETW_MODULE_PATH environment variable. This will enable new use cases, e.g. VS Code.